### PR TITLE
bug: CTA and Survey show double header, Campaign Preview Formatting

### DIFF
--- a/src/app/components/marketing/call-to-action/call-to-action.component.html
+++ b/src/app/components/marketing/call-to-action/call-to-action.component.html
@@ -18,13 +18,6 @@
       </div>
     </div>
   </ion-toolbar>
-
-  <ion-toolbar>
-    <div *ngIf="mainHeader" center title>{{mainHeader}}</div>
-    <div *ngIf="subHeaders">
-      <div *ngFor="let subHeader of subHeaders" center>{{subHeader}}</div>
-    </div>
-  </ion-toolbar>
 </ion-header>
 <ion-content>
   <div external-html *ngIf="hasExternalHtml">

--- a/src/app/components/marketing/call-to-action/call-to-action.component.ts
+++ b/src/app/components/marketing/call-to-action/call-to-action.component.ts
@@ -34,11 +34,11 @@ export class CallToActionComponent implements OnInit {
   hasExternalHtml: boolean;
 
   public get custom_actions(): CampaignAction[] {
-    return this.campaign?.actions?.filter(a => !a.is_default) || [];
+    return this.campaign?.actions?.filter(a => !a.is_default && !a.is_header) || [];
   }
 
   public get default_actions(): CampaignAction[] {
-    return this.campaign?.actions?.filter(a => a.is_default) || [];
+    return this.campaign?.actions?.filter(a => a.is_default && !a.is_header) || [];
   }
 
   public get closeAction(): CampaignAction {

--- a/src/app/components/marketing/call-to-action/call-to-action.component.ts
+++ b/src/app/components/marketing/call-to-action/call-to-action.component.ts
@@ -44,18 +44,18 @@ export class CallToActionComponent implements OnInit {
   public get closeAction(): CampaignAction {
     return this.campaign
       ?.actions
-      ?.filter(a=> a.is_header)
-      ?.find(a=>a.type == 'dismiss' || a.type == 'close');
+      ?.filter(a => a.is_header)
+      ?.find(a => a.type == 'dismiss' || a.type == 'close' || a.type == 'postpone');
   }
 
   public get helpAction(): CampaignAction {
     return this.campaign
       ?.actions
-      ?.filter(a=> a.is_header)
-      ?.find(a=>a.type == 'help');
+      ?.filter(a => a.is_header)
+      ?.find(a => a.type == 'help');
   }
 
-  public get hasHeaderActions():boolean{
+  public get hasHeaderActions(): boolean {
     return this.closeAction != null || this.helpAction != null;
   }
 
@@ -138,7 +138,7 @@ export class CallToActionComponent implements OnInit {
       this.video_url = this.campaign.content_url;
     } else if (this._externalContentSvc.isUrlExternal(this.campaign?.content_url)) {
       this.content_url = this._externalContentSvc.getSafeUrl(this.campaign.content_url);
-    } else if (this.campaign?.content_url){
+    } else if (this.campaign?.content_url) {
       this.hasExternalHtml = true;
       this.content_html = await this._externalContentSvc.getExternalHtml(this.campaign.content_url);
     }

--- a/src/app/components/marketing/campaign-card/campaign-card.component.html
+++ b/src/app/components/marketing/campaign-card/campaign-card.component.html
@@ -5,8 +5,8 @@
         <ion-icon *ngIf="helpAction" name="help-circle-outline"></ion-icon>
         <div spacer></div>
       </div>
-      <div header-title *ngIf="title?.length > 0">
-        <div title-container *ngFor="let titleTxt of title">
+      <div header-title *ngIf="title?.length > 0 || hasHeaderActions">
+        <div title-container *ngFor="let titleTxt of (title || [])">
           <div spacer></div>
           <div title center>{{titleTxt}}</div>
           <div spacer></div>

--- a/src/app/components/marketing/survey/survey/survey.component.ts
+++ b/src/app/components/marketing/survey/survey/survey.component.ts
@@ -46,25 +46,25 @@ export class SurveyComponent implements OnInit {
     return this.current_section?.actions?.filter(a => a.is_default) || [];
   }
 
-  public get hasHeaderActions():boolean{
+  public get hasHeaderActions(): boolean {
     return this.closeAction != null || this.helpAction != null;
   }
 
   public get closeAction(): CampaignAction {
     return this.current_section
       ?.actions
-      ?.filter(a=> a.is_header)
-      ?.find(a=>a.type == 'dismiss' || a.type == 'close');
+      ?.filter(a => a.is_header)
+      ?.find(a => a.type == 'dismiss' || a.type == 'close' || a.type == 'postpone');
   }
 
   public get helpAction(): CampaignAction {
     return this.current_section
       ?.actions
-      ?.filter(a=> a.is_header)
-      ?.find(a=>a.type == 'help');
+      ?.filter(a => a.is_header)
+      ?.find(a => a.type == 'help');
   }
 
-  public get showHeader():boolean {
+  public get showHeader(): boolean {
     return this.hasHeaderActions || this.current_section?.title?.length > 0;
   }
 
@@ -214,8 +214,8 @@ export class SurveyComponent implements OnInit {
           this.state.data[f.field] = this.state.data[f.field] || {};
 
 
-          if(stateData[f.field] != null){
-            if( Array.isArray(stateData[f.field])){
+          if (stateData[f.field] != null) {
+            if (Array.isArray(stateData[f.field])) {
               this.state.data[f.field][f.value || true] = stateData[f.field].indexOf(f.value) > -1 || false;
             } else {
               this.state.data[f.field][f.value || true] = stateData[f.field] == f.value;
@@ -526,7 +526,7 @@ export class SurveyComponent implements OnInit {
       this.video_url = section.content_url;
     } else if (this._externalContentSvc.isUrlExternal(section.content_url)) {
       this.content_url = this._externalContentSvc.getSafeUrl(section.content_url);
-    } else if (section.content_url){
+    } else if (section.content_url) {
       this.hasExternalHtml = true;
       this.content_html = await this._externalContentSvc.getExternalHtml(section.content_url);
     }


### PR DESCRIPTION
* For CTAs and Surveys, the header toolbar appears multiple times
* For CTAs and Surveys, the header actions are also displayed in the standard actions area
* Extended the header the close button to support `dismiss`, `postpone`, and `close` actions types
* Campaign Preview card header formatting when title is not present (shifts right-hand close button to the left)